### PR TITLE
make newer version compatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.sayaka</groupId>
   <artifactId>lr2ir-read-only</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.1</version>
 
   <name>lr2ir-read-only</name>
   <!-- FIXME change it to the project's website -->

--- a/src/main/java/bms/player/beatoraja/ir/LR2IRConnection.java
+++ b/src/main/java/bms/player/beatoraja/ir/LR2IRConnection.java
@@ -101,7 +101,7 @@ public class LR2IRConnection implements IRConnection {
             return rc.create(false, "Error getting myPage, invalid user ID?", null);
         }
         String name = myPage.selectXpath("//table[1]/tbody/tr[1]/td").text();
-        return rc.create(true, "Using user " + name, new IRPlayerData(account.id, account.name, ""));
+        return rc.create(true, "Using user " + name, new IRPlayerData(account.id, name, ""));
     }
 
     public IRResponse<Object> sendPlayData(IRChartData model, IRScoreData score) {

--- a/src/main/java/bms/player/beatoraja/ir/LR2IRConnection.java
+++ b/src/main/java/bms/player/beatoraja/ir/LR2IRConnection.java
@@ -79,11 +79,11 @@ public class LR2IRConnection implements IRConnection {
         }
     }
 
-    public IRResponse<IRPlayerData> register(String id, String pass, String name) {
+    public IRResponse<IRPlayerData> register(IRAccount account) {
         return null;
     }
 
-    public IRResponse<IRPlayerData> login(String id, String pass) {
+    public IRResponse<IRPlayerData> login(IRAccount account) {
         Config c = Config.read();
         try {
             scoredb = new ScoreDatabaseAccessor(c.getPlayerpath() + File.separatorChar + c.getPlayername() + File.separatorChar + "score.db");
@@ -92,16 +92,16 @@ public class LR2IRConnection implements IRConnection {
             e.printStackTrace();
             System.err.println("Error opening score.db, shown ranking will not take PB into account");
         }
-        userId = id;
+        userId = account.id;
         ResponseCreator<IRPlayerData> rc = new ResponseCreator<>();
         try {
-            myPage = Jsoup.connect("http://www.dream-pro.info/~lavalse/LR2IR/search.cgi?mode=mypage&playerid=" + id).get();
+            myPage = Jsoup.connect("http://www.dream-pro.info/~lavalse/LR2IR/search.cgi?mode=mypage&playerid=" + account.id).get();
         } catch (IOException e) {
             e.printStackTrace();
             return rc.create(false, "Error getting myPage, invalid user ID?", null);
         }
         String name = myPage.selectXpath("//table[1]/tbody/tr[1]/td").text();
-        return rc.create(true, "Using user " + name, new IRPlayerData(id, name, ""));
+        return rc.create(true, "Using user " + name, new IRPlayerData(account.id, account.name, ""));
     }
 
     public IRResponse<Object> sendPlayData(IRChartData model, IRScoreData score) {


### PR DESCRIPTION
oraja changes `IRConnection` interface at `0.8.6`.
This PR makes `IRConnection` compatible with `0.8.6` and above.